### PR TITLE
Dynamically extract number of contracts

### DIFF
--- a/contracts/spiders/get_contracts.py
+++ b/contracts/spiders/get_contracts.py
@@ -1,15 +1,29 @@
 import json
 import scrapy
+import requests
+from lxml import html
 
 
 class GetContractsSpider(scrapy.Spider):
     name = 'get_contracts'
     allowed_domains = ['base.gov.pt']
     base_url = 'http://www.base.gov.pt/base2/rest/contratos'
-    ncontracts = 867164
+    ncontracts = 0
     step = 100
 
+    def get_total_number_of_contracts(self):
+
+        URL = "http://www.base.gov.pt/Base/pt/ResultadosPesquisa"
+        page = requests.get(URL, params={'type': 'contratos'})
+        tree = html.fromstring(page.text)
+
+        number_of_contracts = tree.xpath('//p[text()="Foram encontrados "]/span/text()')
+        number_of_contracts = int(number_of_contracts[0])
+        return number_of_contracts
+
     def start_requests(self):
+        self.ncontracts = self.get_total_number_of_contracts()
+
         for i in range(1, self.ncontracts, self.step):
             headers = {'Range': '{}-{}'.format(i, i + self.step - 1)}
             yield scrapy.Request(url=self.base_url, headers=headers,

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ six==1.11.0
 Twisted==17.9.0
 w3lib==1.19.0
 zope.interface==4.4.3
+requests==2.22.0


### PR DESCRIPTION
Fixes #1. 
Gets the total number of contracts from base html portal.
Added requests dependency because the request needed to be synchronous(run before all other requests) and Scrappy requests are asynchronous.